### PR TITLE
add argument on test.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -69,6 +69,7 @@ if __name__ == "__main__":
     parser.add_argument("--seed", type=int, default=32)
     parser.add_argument("--num_workers", type=int, default=4)
     parser.add_argument("--model_path", type=str)
+    parser.add_argument("--num_classes", type=int, default=11)
     args = parser.parse_args()  
     args.ckpt_path = os.path.join(os.getenv('LOG_PATH'), args.ckpt_path)
     test(args)


### PR DESCRIPTION
Hi Kartik,

I was using `script/test.sh` and realized that it needs an additional argument to run properly. I think adding this could benefit everyone. 😊

Just wanted to share this feedback!
<img width="494" height="174" alt="Screenshot 2025-07-15 at 10 41 53 PM" src="https://github.com/user-attachments/assets/4c62639a-00cb-42d9-b4d5-0c2baf0d1f81" />
<img width="434" height="171" alt="Screenshot 2025-07-15 at 10 45 29 PM" src="https://github.com/user-attachments/assets/c6948d8f-194c-4678-b0de-53930be43809" />
